### PR TITLE
Add Remark42 comment counts to index page

### DIFF
--- a/_assets/jr.css
+++ b/_assets/jr.css
@@ -53,13 +53,17 @@ video {
 }
 
 .post-date a,
-.post-date a:visited {
+.post-date a:visited,
+.post-date-comments a,
+.post-date-comments a:visited {
   color: inherit;
   text-decoration: none;
   transition: text-decoration 0.2s;
 }
 
 .post-date a:hover,
-.post-date a:focus {
+.post-date a:focus,
+.post-date-comments a:hover,
+.post-date-comments a:focus {
   text-decoration: underline;
 }

--- a/_assets/poole.css
+++ b/_assets/poole.css
@@ -350,7 +350,8 @@ tbody tr:nth-child(odd) th {
 }
 
 /* Meta data line below post title */
-.post-date {
+.post-date,
+.post-date-comments {
   display: block;
   margin-top: -.5rem;
   margin-bottom: 1rem;

--- a/_includes/remark42-counter.html
+++ b/_includes/remark42-counter.html
@@ -1,0 +1,28 @@
+<script>
+  var remark_config = {
+    host: "{{ site.remark42.host }}",
+    site_id: "{{ site.remark42.site_id }}",
+    components: ["counter"]
+  };
+  (function(c) {
+    for (var i = 0; i < c.length; i++) {
+      var d = document, s = d.createElement("script");
+      s.src = remark_config.host + "/web/" + c[i] + ".js";
+      s.defer = true;
+      (d.head || d.body).appendChild(s);
+    }
+  })(remark_config.components);
+
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.remark42__counter').forEach(function(el) {
+      var obs = new MutationObserver(function() {
+        obs.disconnect();
+        var n = parseInt(el.textContent, 10);
+        if (n === 0) el.textContent = 'No comments';
+        else if (n === 1) el.textContent = 'One comment';
+        else el.textContent = n + ' comments';
+      });
+      obs.observe(el, { childList: true, characterData: true, subtree: true });
+    });
+  });
+</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,6 +22,7 @@ layout: default
   {% endif %}
 </div>
 
+<div id="comments"></div>
 {% include comment-form-remark42.html %}
 
 <div class="previous-next">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: Home
       </a>
     </h1>
 
-    <span class="post-date">{{ post.date | date: "%A, %B %-d, %Y" }}</span>
+    <span class="post-date-comments">{{ post.date | date: "%A, %B %-d, %Y" }} - <a href="{{ post.url }}#comments"><span class="remark42__counter" data-url="{{ post.url | absolute_url }}"></span></a></span>
     
     {% if post.image %}
       <img src="{{ post.image }}" alt="Imagine ilustrativă pentru articolul: {{ post.title }}"/>
@@ -24,6 +24,7 @@ title: Home
     {% endif %}
   </div>
   {% endfor %}
+  {% include remark42-counter.html %}
 </div>
 
 <div class="pagination">


### PR DESCRIPTION
## Summary
- Load Remark42 counter widget on index page via new `_includes/remark42-counter.html`
- Display per-post comment counts inline with the date (formatted as "No comments" / "One comment" / "N comments")
- Comment counts link to `#comments` anchor on the post page
- Add `#comments` anchor div above the Remark42 embed in post layout