### PR TITLE
Run Algolia indexing twice weekly with change detection

### DIFF
--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -2,7 +2,7 @@ name: Index with Algolia
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 3 * * *"
+    - cron: "0 3 * * 1,4"
 permissions:
   contents: read
   actions: read

--- a/.github/workflows/algolia-index.yml
+++ b/.github/workflows/algolia-index.yml
@@ -2,7 +2,10 @@ name: Index with Algolia
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 3 * * 1"
+    - cron: "0 3 * * *"
+permissions:
+  contents: read
+  actions: read
 jobs:
   bundle-algolia:
     runs-on: ubuntu-latest
@@ -11,9 +14,51 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check if posts changed since last successful run
+        id: check_posts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — will index unconditionally."
+            echo "should_index=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_SUCCESS_SHA=$(
+            gh api \
+              "repos/${{ github.repository }}/actions/workflows/algolia-index.yml/runs?status=success&per_page=1" \
+              --jq '.workflow_runs[0].head_sha // empty'
+          )
+
+          if [ -z "$LAST_SUCCESS_SHA" ]; then
+            echo "No prior successful run found — will index."
+            echo "should_index=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Last successful run was at commit: $LAST_SUCCESS_SHA"
+
+          if ! git cat-file -t "$LAST_SUCCESS_SHA" &>/dev/null; then
+            echo "Last success SHA not found in history — will index."
+            echo "should_index=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet "$LAST_SUCCESS_SHA" HEAD -- _posts/; then
+            echo "No changes in _posts/ since last success — skipping."
+            echo "should_index=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected in _posts/ — will index."
+            echo "should_index=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Set up Ruby, install and cache bundle
+        if: steps.check_posts.outputs.should_index == 'true'
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Index with Algolia
+        if: steps.check_posts.outputs.should_index == 'true'
         run: bundle exec jekyll algolia --verbose


### PR DESCRIPTION
## Summary

- Changed schedule from weekly (Mondays) to daily
- Added a change-detection step that compares `_posts/` against the last successful run's commit SHA via the GitHub API
- Skips Ruby setup and Algolia indexing entirely when no posts have changed
- Manual dispatch (`workflow_dispatch`) always indexes unconditionally