### PR TITLE
Add language categories to posts and publish skill

### DIFF
--- a/.claude/skills/publish-post/SKILL.md
+++ b/.claude/skills/publish-post/SKILL.md
@@ -25,6 +25,7 @@ Where `<slug>` is the filename without extension.
 - Copy the file from the `drafts` branch: `git show drafts:<path> > <destination>`
 - The destination is `_posts/{year}/{date}-{slug}.markdown` (e.g., `_posts/2026/2026-04-13-my-post.markdown`). Create the year directory if needed.
 - Add a `date:` field to the frontmatter using the current timestamp (`date +"%Y-%m-%d %H:%M:%S %:z"`). Tell the user what timestamp you used so they can ask to change it before committing.
+- Check the `categories` list in the frontmatter. Every post must include a language category: `english` or `română`. If neither is present, determine the language from the post content and add the appropriate one. Tell the user which language category you added.
 
 ## 4. Commit, push, and open a PR
 

--- a/_posts/2026/2026-04-09-alte-mici-modificari-adio-disqus.markdown
+++ b/_posts/2026/2026-04-09-alte-mici-modificari-adio-disqus.markdown
@@ -5,6 +5,7 @@ date: 2026-04-09 23:42:21 +03:00
 categories:
   - blog history
   - technical
+  - română
 description: După ani de "merge și așa", am mutat comentariile blogului de pe Disqus pe o instanță Remark42 găzduită de mine.
 image: https://content.rusiczki.net/2026/04/disqus-to-remark42.jpg
 ---

--- a/_posts/2026/2026-04-11-pensionarea-mult-prea-intarziata-a-popup-urilor.markdown
+++ b/_posts/2026/2026-04-11-pensionarea-mult-prea-intarziata-a-popup-urilor.markdown
@@ -5,6 +5,7 @@ date: 2026-04-11 14:52:33 +03:00
 categories:
   - blog history
   - technical
+  - română
 description: "Am curățat 28 de articole vechi care încă mai aveau popup-uri JavaScript rămase din era Movable Type. Bonus: tur nostalgic inclus!"
 image: https://content.rusiczki.net/2026/04/pensionarea-popup-urilor.jpg
 ---


### PR DESCRIPTION
## Summary
- Add missing `română` category to two recent posts (2026-04-09, 2026-04-11)
- Update publish-post skill to check for and add a language category (`english` or `română`) during publishing