### PR TITLE
Trigger Algolia indexing when a new post is published

### DIFF
--- a/.github/workflows/jekyll-build-test-and-deploy.yml
+++ b/.github/workflows/jekyll-build-test-and-deploy.yml
@@ -1,8 +1,11 @@
 name: Jekyll Build, Test and Deploy
 on:
   push:
-    branches: 
+    branches:
       - master
+permissions:
+  contents: read
+  actions: write
 jobs:
   bundle-build-test-deploy:
     runs-on: ubuntu-latest
@@ -25,4 +28,17 @@ jobs:
           remote_path: ${{ secrets.DEPLOY_PATH }}
           remote_host: ${{ secrets.DEPLOY_HOST }}
           remote_user: ${{ secrets.DEPLOY_USER }}
-          remote_key: ${{ secrets.DEPLOY_KEY }}  
+          remote_key: ${{ secrets.DEPLOY_KEY }}
+      - name: Trigger Algolia indexing for new posts
+        if: github.event.before != '0000000000000000000000000000000000000000'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NEW_POSTS=$(gh api "repos/${{ github.repository }}/compare/${{ github.event.before }}...${{ github.sha }}" \
+            --jq '[.files[] | select(.status == "added" and (.filename | startswith("_posts/")))] | length')
+          if [ "$NEW_POSTS" -gt 0 ]; then
+            echo "New post(s) detected — triggering Algolia indexing."
+            gh workflow run algolia-index.yml
+          else
+            echo "No new posts — skipping Algolia trigger."
+          fi


### PR DESCRIPTION
## Summary
- Adds a post-deploy step to the build/deploy workflow that detects new files added under `_posts/` (using the GitHub compare API against `github.event.before`) and invokes the Algolia indexing workflow via `gh workflow run` when one is found.
- Edits to existing posts are intentionally ignored here — they'll still be picked up by the existing Mon/Thu schedule.
- Declares `contents: read` / `actions: write` at the workflow level so the default token can dispatch the sibling workflow.