### PR TITLE
Publish "Plimbarea tradițională de 1 mai spre locuri legendare"

### DIFF
--- a/_posts/2026/2026-05-31-plimbarea-traditionala-de-1-mai-spre-locuri-legendare.markdown
+++ b/_posts/2026/2026-05-31-plimbarea-traditionala-de-1-mai-spre-locuri-legendare.markdown
@@ -1,0 +1,140 @@
+---
+layout: post
+title: "Plimbarea tradițională de 1 mai spre locuri legendare"
+date: 2026-05-31 20:31:51 +03:00
+categories:
+- cronică
+- sport
+- română
+- foto
+image: https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619614-1556720974000-1000x563.jpg
+description: O retrospectivă a picnicurilor de 1 mai din Grădina Danila și a vizitelor nostalgice din ultimii ani.
+---
+Așa, sau ceva de genul mi-am intitulat plimbările de 1 mai pe Strava de câțiva ani... Și mă gândeam să scriu o explicație / retrospectivă:
+
+- **Clasică** - pentru că deja de câțiva ani buni fac această plimbare de remember.
+- **Locuri legendare** - pentru că pe vremuri în acel loc s-au desfășurat niște picnicuri de 1 mai foarte reușite.
+
+Ieșirile de demult credeam că au fost trei, două concentrate în jur de 2003 și 2004 și apoi unul mai târziu. Ca să-mi validez amintirile, în dimineața zilei de 2 mai am scris un mic script pentru a putea explora arhiva mea foto. După ce a fost gata, am văzut că, conform pozelor, picnicurile au fost de fapt în 2004, urmat de un an de [pauză](https://www.rusiczki.net/2005/05/01/biking-around-the-town/), și apoi în 2006 și 2007. Dar, *răsturnare de situație*! Când m-am apucat de redactat acest articol am găsit chiar aici pe blog [un articol despre ediția din 2004](https://www.rusiczki.net/2004/05/03/the-official-may-1st-food-fest/) care menționează cât de reușită a fost cea din anul precedent. La care, în mod surprinzător, se pare că nu am făcut poze...
+
+Așadar edițiile de odinioară s-au desfășurat în **2003**, **2004**, **2006** și **2007**.
+
+Despre cel din 2003 nu-mi amintesc nimic, dar cel din 2004 a devenit *absolut legendar* în cercul de prieteni, datorită unor filmări făcute cu [proaspătul meu aparat foto](https://www.rusiczki.net/2004/01/30/digital-camera-upgrade/) care știa și filma și pentru că era multă, *foarte multă*, energie și veselie tinerească. Ediția din 2006 a fost deja mai cuminte iar 2007 a fost cea mai cuminte.
+
+Revenind la *loc*: Este vorba de o poiană în pantă numită Grădina Danila (*Danila Kert*), de fapt versantul unui deal, situată la câteva sute de metri de ruinele Puțului Francisc din apropierea orașului meu natal. [Am pus-o și pe OSM.](https://www.openstreetmap.org/way/593658818) Mai precis grătarele se făceau lângă o construcție din beton, un bazin de apă aflat în partea superioară a acestei poieni, la liziera pădurii. Am pus întrebări despre scopul lui dar nu a știut nimeni să-mi răspundă. Aduna apa dintr-un izvor aflat la câțiva metri distanță, dar alimenta ce? Nu știu...
+
+Au trecut 11 ani, între timp organizatorul principal al acestor ieșiri a plecat departe peste hotare, nouă ni s-a născut copilul și după un 2017 pe care l-am simțit destul de "îmbâcsit", la începutul lui 2018 [m-am pus pe alergat](https://www.rusiczki.net/2018/07/12/alergarea-din-perspectiva-unui-incepator/) și am ajuns, cred că mai mult din greșeală, din nou în acel loc tocmai în data de 1 mai. Am revenit în anul următor și apoi s-a format un soi de obicei și ambiție să trec în fiecare an pe acolo.
+
+Destul de recent, acum 2 sau 3 ani mi-am dat seama că s-au adunat deja mai multe vizite de remember decât picnicuri propriu-zise... Momentan contorul stă la 4 ediții originale versus 9 vizite nostalgice. Ce am observat a fost că în ultimii ani a devenit parcă mai animată pădurea, dar în primii ani de revizitare nu prea erau oameni prin zonă. Nici măcar mai jos, în zonele mai accesibile.
+
+Și acum niște tehnicalități despre redactare (oamenii normali pot sări peste acest paragraf): mi-a venit ideea să scriu articolul chiar în timpul plimbării din data de 1, dar cum înainte de ieșire am grătărit cu orele pe acasă nu am mai avut energie în acea seară / dupămasă. În data de 2, sâmbătă dimineața l-am pus pe Claude să-mi scrie o mică aplicație de explorat arhiva foto. Apoi când mi-am dat seama că am material vizual din belșug dar neavând chef să editez și să redimensionez manual zeci de fișiere, am dezgropat un alt proiect spre care am "diversificat" în momentul în care descoperisem Claude Code: un manager de media pentru site-uri generate static. Apoi înapoi la muncă și viață, dar între timp am tot lucrat și finisat aplicația până am adus-o la starea în care toate pozele și filmulețele care ilustrează acest articol au fost încărcate și prelucrate cu el.
+
+Și în încheiere să nu uităm de ce am venit, iată **arhiva vizuală**!
+
+**2004** - A doua ediție. **Legendară!**
+
+[![Dealul Minei din Baia Sprie, văzut dinspre nord est.](https://content.rusiczki.net/2026/05/1-mai/2004/263-6303-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2004/263-6303.jpg)
+
+[![Picnicul din 2004 în plină desfășurare](https://content.rusiczki.net/2026/05/1-mai/2004/263-6366-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2004/263-6366.jpg)
+
+[![Vizita unei turme](https://content.rusiczki.net/2026/05/1-mai/2004/263-6325-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2004/263-6325.jpg)
+
+<video src="https://content.rusiczki.net/2026/05/1-mai/2004/263-6388-web.mp4" poster="https://content.rusiczki.net/2026/05/1-mai/2004/263-6388-poster.jpg" controls></video>
+Povestea ierbii de la Hoia (cu pișat)
+
+<video src="https://content.rusiczki.net/2026/05/1-mai/2004/263-6392-web.mp4" poster="https://content.rusiczki.net/2026/05/1-mai/2004/263-6392-poster.jpg" controls></video>
+Un mic pogo
+
+**2006** - Mai cuminte (nu am inclus poze cu gașca dar nu am fost doar noi)
+
+[![Tot Dealul Minei, tot văzut din Grădina Danila.](https://content.rusiczki.net/2026/05/1-mai/2006/img-1274-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2006/img-1274.jpg)
+
+[![Fac focul.](https://content.rusiczki.net/2026/05/1-mai/2006/img-1271-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2006/img-1271.jpg)
+
+[![Ioana picură slănină pe pâine.](https://content.rusiczki.net/2026/05/1-mai/2006/img-1281-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2006/img-1281.jpg)
+
+[![Cred că se jucau amicii cu frisbee.](https://content.rusiczki.net/2026/05/1-mai/2006/img-1308-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2006/img-1308.jpg)
+
+**2007** - Și mai cuminte
+
+[![Dealul Minei](https://content.rusiczki.net/2026/05/1-mai/2007/img-7537-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2007/img-7537.jpg)
+
+[![Vârful Dealului Minei, cu zoom](https://content.rusiczki.net/2026/05/1-mai/2007/img-7498-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2007/img-7498.jpg)
+
+[![Grătar](https://content.rusiczki.net/2026/05/1-mai/2007/img-7468-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2007/img-7468.jpg)
+
+[![Gașca și Dealul Minei](https://content.rusiczki.net/2026/05/1-mai/2007/img-7464-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2007/img-7464.jpg)
+
+*..... 10 ani de pauză ......*
+
+**2018** - Reîntoarcerea
+
+[![Dealul Minei, la șase jumate dupămasa și cer înorat](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182232-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182232.jpg)
+
+[![Căminul (construcția de beton) și Dealul Minei](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182314-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182314.jpg)
+
+[![Picioarele mele sexoase pe colțul căminului de apă](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182421-750x1000.jpg)](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182421.jpg)
+
+[![Locul văzut de jos, cu liziera pădurii (proaspăt tăiate)](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182146-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2018/img-20180501-182146.jpg)
+
+**2019** - Întoarcerea cu Osmo Pocket
+
+[![Căminul de apă și Dealul Minei (pozate de data asta cu prospătul meu Osmo Pocket)](https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619608-1556720772000-1000x563.jpg)](https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619608-1556720772000.jpg)
+
+[![Izvorul unde odinioară ne țineam berile la rece](https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619610-1556720820000-1000x563.jpg)](https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619610-1556720820000.jpg)
+
+[![Dealul Minei într-o lumină de vis](https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619614-1556720974000-1000x563.jpg)](https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619614-1556720974000.jpg)
+
+**2020** - Cu ocazia pandemiei, am mers de fapt în 2 mai
+
+[![Pandemie sau nu, Dealul Minei arăta la fel](https://content.rusiczki.net/2026/05/1-mai/2020/img-20200502-144809-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2020/img-20200502-144809.jpg)
+
+[![Cele 2 partenere de drum](https://content.rusiczki.net/2026/05/1-mai/2020/img-20200502-144845-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2020/img-20200502-144845.jpg)
+
+**2021** - Natura super întârziată
+
+[![În 2021 cu natura întarziată bine](https://content.rusiczki.net/2026/05/1-mai/2021/img-20210501-163228-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2021/img-20210501-163228.jpg)
+
+[![Căminul de apă](https://content.rusiczki.net/2026/05/1-mai/2021/img-20210501-163100-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2021/img-20210501-163100.jpg)
+
+**2022** - Cu Anna, Ioana, GoPro și drona!
+
+[![Baia Sprie văzută din drona poziționată deasupra Grădinii Danila](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404327290-1000x563.jpg)](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404327290.jpg)
+
+[![Grădina Danila în toată splendoarea ei](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404326823-1000x563.jpg)](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404326823.jpg)
+
+[![Vedere cu căminul și liziera pădurii](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404327786-1000x563.jpg)](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404327786.jpg)
+
+[![Fetele la beton](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404325564-1000x563.jpg)](https://content.rusiczki.net/2026/05/1-mai/2022/dji-export-1651404325564.jpg)
+
+**2023** - Revenirea cu fetele și Olympus-ul renăscut
+
+[![Dealul Minei din nou într-o lumină superbă](https://content.rusiczki.net/2026/05/1-mai/2023/p5010646-1000x664.jpg)](https://content.rusiczki.net/2026/05/1-mai/2023/p5010646.jpg)
+
+[![Căminul și liziera crescută la loc](https://content.rusiczki.net/2026/05/1-mai/2023/p5010648-1000x664.jpg)](https://content.rusiczki.net/2026/05/1-mai/2023/p5010648.jpg)
+
+[![Vedere de la umbră](https://content.rusiczki.net/2026/05/1-mai/2023/p5010651-1000x664.jpg)](https://content.rusiczki.net/2026/05/1-mai/2023/p5010651.jpg)
+
+[![Fetele pe drumul de conexiune](https://content.rusiczki.net/2026/05/1-mai/2023/p5010660-1000x664.jpg)](https://content.rusiczki.net/2026/05/1-mai/2023/p5010660.jpg)
+
+**2024** - Anul misterios
+
+Nu am înregistrat cu Strava, am [doar o poză](https://content.rusiczki.net/2026/05/1-mai/2024/img-20240501-163031.jpg) de pe drum.
+
+**2025** - Cu Anna și Ioana, văzut prin lentila Galaxy S24 Ultra
+
+[![Dealul Minei văzut cu Galaxy S24 Ultra](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-145420-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-145420.jpg)
+
+[![Căminul de apă într-o lumină](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-144854-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-144854.jpg)
+
+[![Ultra Wide!](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-145437-1000x706.jpg)](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-145437.jpg)
+
+[![Fetele execută ceva dans :)](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-145704-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2025/20250501-145704.jpg)
+
+**2026** - Cu Anna și Ioana
+
+[![Dealul Minei în anul curent](https://content.rusiczki.net/2026/05/1-mai/2026/20260501-145446-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2026/20260501-145446.jpg)
+
+[![Mica gașcă](https://content.rusiczki.net/2026/05/1-mai/2026/20260501-145616-750x1000.jpg)](https://content.rusiczki.net/2026/05/1-mai/2026/20260501-145616.jpg)
+
+[![O ultimă privire înapoi](https://content.rusiczki.net/2026/05/1-mai/2026/20260501-145943-1000x750.jpg)](https://content.rusiczki.net/2026/05/1-mai/2026/20260501-145943.jpg)

--- a/_posts/2026/2026-05-31-plimbarea-traditionala-de-1-mai-spre-locuri-legendare.markdown
+++ b/_posts/2026/2026-05-31-plimbarea-traditionala-de-1-mai-spre-locuri-legendare.markdown
@@ -4,7 +4,6 @@ title: "Plimbarea tradițională de 1 mai spre locuri legendare"
 date: 2026-05-31 20:31:51 +03:00
 categories:
 - cronică
-- sport
 - română
 - foto
 image: https://content.rusiczki.net/2026/05/1-mai/2019/org-photo-6619614-1556720974000-1000x563.jpg


### PR DESCRIPTION
Retrospectivă a picnicurilor de 1 mai din Grădina Danila (2003–2007) și a vizitelor nostalgice anuale din 2018 încoace, cu arhivă foto și video completă.